### PR TITLE
add subscribe function

### DIFF
--- a/src/requestUtil.js
+++ b/src/requestUtil.js
@@ -20,3 +20,20 @@ export async function sendMutation(mutation, variables, refetchQueries) {
     }
     return data;
 }
+
+export function sendSubscription(query, variables, callback, errorFunc, ignoreCache) {
+    const params = { query, variables };
+    if (ignoreCache) {
+      params.fetchPolicy = "network-only";
+    }
+
+    getApolloClient().subscribe(params)
+    .subscribe({
+      next(data) {
+        callback(data)
+      },
+      error(err){
+        errorFunc(err)  
+      }
+    });
+}


### PR DESCRIPTION
With "taro-link-ws" and "taro-ws", We can use apollo subscription in Taro now.

So that i try to add a new function to use apollo subscribe function with "taro-apollo".